### PR TITLE
Allow .meta() to add metadata to CQL fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -444,11 +444,25 @@ function defaultify(type, validator, options) {
  * @returns {JoiMetaDefinition} - the result
  */
 function findMeta(any, key) {
-  key = key || 'cql';
-  var meta = (any.describe().meta || []).filter(function (m) {
-    return key in m;
-  });
-  return meta[meta.length - 1];
+  var searchKey = key || 'cql';
+  var isCql = searchKey === 'cql';
+  var meta = {};
+  var allMetas = (any.describe().meta || []);
+  var found = false;
+  for (var i = 0; i < allMetas.length; i++) {
+    if (found || (searchKey in allMetas[i])) {
+      if (isCql) {
+        // If 'cql', merge all subsequent metadata in
+        Object.assign(meta, allMetas[i]);
+      } else {
+        // Otherwise, find last instance of that key
+        meta = allMetas[i];
+      }
+      found = true;
+    }
+  }
+
+  return found ? meta : void 0;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Create cql type definitions from joi schema validations",
   "main": "index.js",
   "scripts": {
-    "test": "gulp test && npm outdated"
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",
@@ -13,12 +13,13 @@
   "author": "GoDaddy",
   "license": "MIT",
   "dependencies": {
-    "joi": "^8.0.4",
+    "joi": "~8.0.0",
     "uuid": "^2.0.1"
   },
   "devDependencies": {
     "assume": "^1.3.1",
-    "godaddy-test-tools": "^3.1.0",
-    "gulp": "^3.9.0"
+    "godaddy-test-tools": "^3.3.1",
+    "gulp": "^3.9.1",
+    "jshint": "2.8.0"
   }
 }

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -211,6 +211,41 @@ describe('joi-of-cql', function () {
       describe('.' + type, generateDescription(type, examples[type]));
     });
 
+    describe('.meta', function () {
+      var schema = {
+        id: joiOfCql.cql.uuid({ default: 'v4' }),
+        anotherId: joiOfCql.cql.uuid({ default: 'v4' }).meta({ some: 'metadata' }),
+        someField: joiOfCql.cql.int()
+          .meta({ some: 'metadata' })
+          .meta({ more: 'metadata' })
+          .meta({ some: 'overwritten' })
+      };
+
+      it('should merge metadata into CQL metadata', function () {
+        var cqlSchema = joiOfCql.object(schema).toCql();
+        assume(joiOfCql.object(schema).toCql().id)
+          .deep.equals({
+            cql: true,
+            type: 'uuid',
+            default: 'v4'
+          });
+        assume(cqlSchema.anotherId)
+          .deep.equals({
+            cql: true,
+            type: 'uuid',
+            default: 'v4',
+            some: 'metadata'
+          });
+        assume(cqlSchema.someField)
+          .deep.equals({
+            cql: true,
+            type: 'int',
+            some: 'overwritten',
+            more: 'metadata'
+          });
+      });
+    });
+
     describe('.json', function () {
       var schema = {
         id: joiOfCql.cql.uuid({ default: 'v4' }),


### PR DESCRIPTION
Example usage (from `datastar` integration tests):
```
  foo: joi.object({
    foo_id: cql.uuid(),
    secondary_id: cql.uuid().meta({ nullConversion: false }),
    nullable_id: cql.uuid(),
    something: cql.text()
  }).partitionKey('foo_id')
    .clusteringKey('secondary_id')
```