### PR TITLE
Fix issue where finding a particuar non-cql key that has been chained on fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -450,18 +450,18 @@ function findMeta(any, key) {
   var allMetas = (any.describe().meta || []);
   var found = false;
   for (var i = 0; i < allMetas.length; i++) {
-    if (found || (searchKey in allMetas[i])) {
+    var hasKey = (searchKey in allMetas[i]);
+    if (found || hasKey) {
       if (isCql) {
         // If 'cql', merge all subsequent metadata in
         Object.assign(meta, allMetas[i]);
-      } else {
+      } else if (hasKey) {
         // Otherwise, find last instance of that key
         meta = allMetas[i];
       }
       found = true;
     }
   }
-
   return found ? meta : void 0;
 }
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -440,6 +440,56 @@ describe('joi-of-cql', function () {
       });
     });
   });
+
+  describe('schema tests', function () {
+    let albumSchema;
+    beforeEach(function () {
+      albumSchema = joiOfCql.object({
+        artist_id: joiOfCql.cql.uuid(),
+        album_id: joiOfCql.cql.uuid(),
+        name: joiOfCql.cql.text(),
+        track_list: joiOfCql.cql.list(joiOfCql.cql.text()),
+        song_list: joiOfCql.cql.list(joiOfCql.cql.uuid()),
+        release_date: joiOfCql.cql.timestamp(),
+        create_date: joiOfCql.cql.timestamp(),
+        update_date: joiOfCql.cql.timestamp(),
+        producer: joiOfCql.cql.text()
+      }).partitionKey('artist_id')
+        .clusteringKey('album_id')
+        .rename('id', 'album_id', { ignoreUndefined: true });
+    });
+
+    it('.partitionKey() should return the defined partition key', function () {
+      assume(albumSchema.partitionKey()).equals('artist_id');
+    });
+
+    it('.clusteringKey() should return the defined clustering key', function () {
+      assume(albumSchema.clusteringKey()).equals('album_id');
+    });
+
+    it('.lookupKeys() should return an empty array', function () {
+      assume(albumSchema.lookupKeys()).deep.equals([]);
+    });
+
+    it('.aliases() should return the aliased columns', function () {
+      assume(albumSchema.aliases()).deep.equals({ id: 'album_id' });
+    });
+
+    it('.toCql() should return the CQL type schema', function () {
+      const cqlSchema = albumSchema.toCql();
+      assume(cqlSchema.artist_id.type).equals('uuid');
+      assume(cqlSchema.album_id.type).equals('uuid');
+      assume(cqlSchema.name.type).equals('text');
+      assume(cqlSchema.producer.type).equals('text');
+      assume(cqlSchema.track_list.type).equals('list');
+      assume(cqlSchema.track_list.listType).equals('text');
+      assume(cqlSchema.song_list.type).equals('list');
+      assume(cqlSchema.song_list.listType).equals('uuid');
+      assume(cqlSchema.release_date.type).equals('timestamp');
+      assume(cqlSchema.create_date.type).equals('timestamp');
+      assume(cqlSchema.update_date.type).equals('timestamp');
+    });
+  });
 });
 
 function generateDescription(type, data) {


### PR DESCRIPTION
`joi-of-cql` unit tests:
```
$ npm test

> joi-of-cql@2.0.0 test /Users/scommisso/Projects/joi-of-cql
> gulp unit

[10:00:30] Using gulpfile ~/Projects/joi-of-cql/gulpfile.js
[10:00:30] Starting 'unit'...


  joi-of-cql
    .cql
      .ascii
        ✓ should pass validation with "test"
        ✓ should pass validation with ""
        ✓ should fail validation with "true"
        ✓ should fail validation with "0"
        ✓ should fail validation with "[object Object]"
        ✓ should fail validation with ""
      .bigint
        ✓ should pass validation with "0"
        ✓ should pass validation with "1"
        ✓ should pass validation with "-1"
        ✓ should pass validation with "9223372036854776000"
        ✓ should pass validation with "-92233720368547758080"
        ✓ should pass validation with "9007199254740991"
        ✓ should pass validation with "-9007199254740991"
        ✓ should pass validation with "-9007199254740991"
        ✓ should fail validation with ""
        ✓ should fail validation with "Infinity"
        ✓ should fail validation with "-Infinity"
        ✓ should fail validation with "−9,223,372,036,854,775,808"
        ✓ should fail validation with "−92233720368547758080"
      .blob
        ✓ should pass validation with "Just a bunch of text"
        ✓ should pass validation with "ZY"
        ✓ should pass validation with "4a75737420612062756e6368206f662074657874"
        ✓ should pass validation with "asdkjhkajsdh"
      .boolean
        ✓ should pass validation with "true"
        ✓ should pass validation with "false"
        ✓ should fail validation with "0"
        ✓ should fail validation with "1"
        ✓ should fail validation with ""
        ✓ should fail validation with "[object Object]"
        ✓ should fail validation with ""
      .counter
        ✓ should pass validation with "0"
        ✓ should pass validation with "1"
        ✓ should pass validation with "-1"
        ✓ should pass validation with "9223372036854776000"
        ✓ should pass validation with "-92233720368547758080"
        ✓ should pass validation with "9007199254740991"
        ✓ should pass validation with "-9007199254740991"
        ✓ should pass validation with "-9007199254740991"
        ✓ should fail validation with ""
        ✓ should fail validation with "Infinity"
        ✓ should fail validation with "-Infinity"
        ✓ should fail validation with "−9,223,372,036,854,775,808"
        ✓ should fail validation with "−92233720368547758080"
      .decimal
        ✓ should pass validation with "123.1"
        ✓ should pass validation with "1"
        ✓ should pass validation with "0"
        ✓ should pass validation with "-1"
        ✓ should pass validation with "-123.23"
        ✓ should fail validation with "null"
        ✓ should fail validation with "true"
        ✓ should fail validation with ""
        ✓ should fail validation with "xyz"
        ✓ should fail validation with "abc"
        ✓ should fail validation with "[object Object]"
        ✓ should fail validation with ""
      .double
        ✓ should pass validation with "123.1"
        ✓ should pass validation with "1"
        ✓ should pass validation with "0"
        ✓ should pass validation with "-1"
        ✓ should pass validation with "-123.23"
        ✓ should fail validation with "null"
        ✓ should fail validation with "true"
        ✓ should fail validation with ""
        ✓ should fail validation with "xyz"
        ✓ should fail validation with "abc"
        ✓ should fail validation with "[object Object]"
        ✓ should fail validation with ""
      .float
        ✓ should pass validation with "123.1"
        ✓ should pass validation with "1"
        ✓ should pass validation with "0"
        ✓ should pass validation with "-1"
        ✓ should pass validation with "-123.23"
        ✓ should fail validation with "null"
        ✓ should fail validation with "true"
        ✓ should fail validation with ""
        ✓ should fail validation with "xyz"
        ✓ should fail validation with "abc"
        ✓ should fail validation with "[object Object]"
        ✓ should fail validation with ""
      .inet
        ✓ should pass validation with "127.0.0.1"
        ✓ should pass validation with "192.168.5.1"
        ✓ should pass validation with "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"
        ✓ should pass validation with "FE80::0202:B3FF:FE1E:8329"
        ✓ should pass validation with "2001:db8:a0b:12f0::1"
        ✓ should fail validation with "www.godaddy.com"
        ✓ should fail validation with "true"
        ✓ should fail validation with "-1"
        ✓ should fail validation with "0"
        ✓ should fail validation with "[object Object]"
        ✓ should fail validation with ""
        ✓ should fail validation with "null"
      .int
        ✓ should pass validation with "0"
        ✓ should pass validation with "1"
        ✓ should pass validation with "2147483647"
        ✓ should pass validation with "-2147483647"
        ✓ should pass validation with "2147483647"
        ✓ should pass validation with "-2147483647"
        ✓ should fail validation with ""
        ✓ should fail validation with "a"
        ✓ should fail validation with "[object Object]"
        ✓ should fail validation with ""
      .text
        ✓ should pass validation with "test"
        ✓ should pass validation with ""
        ✓ should fail validation with "true"
        ✓ should fail validation with "0"
        ✓ should fail validation with "[object Object]"
        ✓ should fail validation with ""
      .timestamp
        ✓ should pass validation with "2015-09-18T00:59:41.840Z"
        ✓ should pass validation with "1566838831235"
        ✓ should pass validation with "2019-08-26T17:00:31.235Z"
        ✓ should pass validation with "2011-02-03 04:45"
        ✓ should pass validation with "2011-02-03 04:45:55"
        ✓ should pass validation with "2011-02-03 04:45Z"
        ✓ should pass validation with "2011-02-03 04:45:55Z"
        ✓ should pass validation with "2011-02-03T04:45"
        ✓ should pass validation with "2011-02-03T04:45Z"
        ✓ should pass validation with "2011-02-03T04:45:55"
        ✓ should pass validation with "2011-02-03T04:45:55Z"
        ✓ should pass validation with "2011-02-03"
        ✓ should pass validation with "2011-02-03 04:05+0000"
        ✓ should pass validation with "2011-02-03 04:05:00+0000"
        ✓ should pass validation with "2011-02-03T04:05+0000"
        ✓ should pass validation with "2011-02-03T04:05:00+0000"
        ✓ should fail validation with ""
        ✓ should fail validation with "a"
        ✓ should fail validation with "2011-02-03Z"
        ✓ should fail validation with "[object Object]"
        ✓ should fail validation with ""
        ✓ should match "/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d+Z$/" when given the default of "create" during a "create" operation
        ✓ should match "/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d+Z$/" when given the default of "update" during a "create" operation
        ✓ should match "undefined" when given the default of "create" during a "update" operation
        ✓ should match "/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d+Z$/" when given the default of "update" during a "update" operation
      .timeuuid
        ✓ should pass validation with "0310e440-c823-11e9-b0b6-9d2eaf3aaf11"
        ✓ should pass validation with "00000000-0000-0000-0000-000000000000"
        ✓ should fail validation with ""
        ✓ should fail validation with "a"
        ✓ should fail validation with "1"
        ✓ should fail validation with "-3"
        ✓ should fail validation with "[object Object]"
        ✓ should fail validation with ""
        ✓ should match "/^00000000-0000-0000-0000-000000000000$/" when given the default of "empty" during a "create" operation
        ✓ should match "/^[A-F0-9]{8}(?:-[A-F0-9]{4}){3}-[A-F0-9]{12}$/i" when given the default of "v1" during a "create" operation
      .uuid
        ✓ should pass validation with "f9eaf663-5367-4790-a45c-e5ed9b0a54fd"
        ✓ should fail validation with ""
        ✓ should fail validation with "a"
        ✓ should fail validation with "1"
        ✓ should fail validation with "-3"
        ✓ should fail validation with "[object Object]"
        ✓ should fail validation with ""
        ✓ should match "/^00000000-0000-0000-0000-000000000000$/" when given the default of "empty" during a "create" operation
        ✓ should match "/^[A-F0-9]{8}(?:-[A-F0-9]{4}){3}-[A-F0-9]{12}$/i" when given the default of "v4" during a "create" operation
      .varchar
        ✓ should pass validation with "test"
        ✓ should pass validation with ""
        ✓ should fail validation with "true"
        ✓ should fail validation with "0"
        ✓ should fail validation with "[object Object]"
        ✓ should fail validation with ""
      .varint
        ✓ should pass validation with "1"
        ✓ should pass validation with "-2"
        ✓ should pass validation with "2345"
        ✓ should pass validation with "-1234567890123456789012345678901234567890"
        ✓ should pass validation with "9876543211234567890123456789012345678901234567890"
        ✓ should fail validation with ""
        ✓ should fail validation with "a"
        ✓ should fail validation with "[object Object]"
        ✓ should fail validation with ""
      .map
        ✓ should pass validation with "[object Object]"
        ✓ should fail validation with "[object Object]"
      .list
        ✓ should pass validation with ",123,abc"
        ✓ should pass validation with "[object Object]"
        ✓ should pass validation with "[object Object]"
        ✓ should pass validation with "[object Object]"
        ✓ should fail validation with ",123,abc"
        ✓ should fail validation with "123,45"
        ✓ should fail validation with ",,54"
      .set
        ✓ should pass validation with ",123,abc"
        ✓ should pass validation with "[object Object]"
        ✓ should pass validation with "[object Object]"
        ✓ should pass validation with "[object Object]"
        ✓ should fail validation with ",123,abc"
        ✓ should fail validation with "123,45"
        ✓ should fail validation with ",,54"
      .meta
        ✓ should merge metadata into CQL metadata
      .json
        ✓ should serialize to a string on validation
        ✓ should accept an array
      .map
        ✓ should serialize to an empty object when null
        ✓ should deserialize to an empty object when null
      .list
        ✓ should serialize to an empty array when null
        ✓ should deserialize to an empty array when null
      .set
        ✓ should serialize to an empty array when null
        ✓ should deserialize to an empty array when null
    .create
      ✓ should create a validator for a CQL definition
    joi modifications
      .toCql
        ✓ should return an object that contains the CQL type
        ✓ should return undefined for schema validations that are not CQL types
    modifications to object
      .lookupKeys
        ✓ should create a joi validation object when passed arguments
        ✓ should return the value when no arguments are passed
        ✓ should return an empty array when no arguments are provided and there are no lookupKeys found
        ✓ should not be on a non-object schema
      .partitionKey
        ✓ should create a joi validation object when passed arguments
        ✓ should return an array when no arguments are passed
        ✓ should return an empty array when no arguments are provided and there is no partitionKey found
        ✓ should not be on a non-object schema
        ✓ should return the value when no arguments are passed
        ✓ should return the last value assigned to clusteringKey/partitionKey
        ✓ should return an array when nulling out a previous partitionKey value of the schema
      .clusteringKey
        ✓ should create a joi validation object when passed arguments
        ✓ should return the value when no arguments are passed
        ✓ should return an empty array when no arguments are provided and there is no clusteringKey found
        ✓ should not be on a non-object schema
        ✓ should return an array when no arguments are passed
      .aliases
        ✓ should create a joi validation object when passed arguments
        ✓ should return the value when no arguments are passed
        ✓ should return an empty array when no arguments are provided and there is no aliases found
        ✓ should not be on a non-object schema
    schema tests
      ✓ .partitionKey() should return the defined partition key
      ✓ .clusteringKey() should return the defined clustering key
      ✓ .lookupKeys() should return an empty array
      ✓ .aliases() should return the aliased columns
      ✓ .toCql() should return the CQL type schema


  219 passing (120ms)

```

Also ran `datastar` tests via `npm link`:

```
> mocha -R spec test/



  Datastar
    ✓ should create datastar instance without pre-heating connection
    ✓ should create datastar instance with pre-heating connection

  Model
    Artist
      ✓ should create a model
      ✓ should create tables (40ms)
      ✓ should create
      ✓ should update
      ✓ should find
      ✓ should remove (1014ms)
    update on List type
      ✓ create a person model
      ✓ should create a person model with a list
      ✓ should handle an update operation that prepends a value on the list (1010ms)
      ✓ should handle an update for an append operation
      ✓ should handle an update for a remove operation
      ✓ should handle an update for an index operation
      ✓ should handle an update that replaces the list
      ✓ should fetch a person with the simpler find syntax (object)
      ✓ should fetch a person with the simpler find syntax (string)
      ✓ should completely remove the entity
    Composite Partition Keys
      ✓ should create the table when defining the model with composite partition key
      ✓ should be able to create
      ✓ should be able to update that same record
      ✓ should error with simpler find syntax with more complicated key (string)
      ✓ should be able to find the record
      ✓ should error when updating without the hash in the composite key
      ✓ should error when we pass in a key that doesnt exist when running update
      ✓ should error when we pass in a key that doesnt exist when running create
      ✓ should remove the record
    Clustering Keys
      ✓ should create a table with secondary/clustering keys (38ms)
      ✓ should create an album with proper IDs
      ✓ should update an album
      ✓ should find an album
      ✓ should error when updating without the artistId
      ✓ should remove an Album
    Lookup Tables
      ✓ should be created when defining a model with lookupKeys and ensureTables is true (113ms)
      ✓ should be able to write all lookup tables
      ✓ should be able to update all lookup tables when not changing the primary keys
      ✓ should be able to find by all the `primaryKeys` and return the same value
      ✓ should be able to update to all lookup tables when changing a primaryKey for a lookup table and ensure the old primaryKey reference was deleted (510ms)
      ✓ should find all by all primaryKeys, specifically the new one and have equal values
      ✓ should properly update when not passing a previous value and doing a find operation to fetch previous state
      ✓ should fail to update when calling save on the model if no columns changed directly
      ✓ should update when calling save on the model and not call an extra findOne since we have the previous state
      ✓ should remove from all lookup tables
      ✓ should error when trying to remove without required attributes
    foo
      ✓ should create a table with an alter statement (40ms)
      ✓ should create multiple records in the database
      ✓ should create a record in the database that will properly expire with given ttl (3018ms)
      ✓ should create a record in the database that will expire but still be found before it reaches given ttl (3017ms)
      ✓ should update a record in the database that will expire with given ttl (2008ms)
      ✓ should update a record in the database that can be found before it reaches ttl (2017ms)
      ✓ should update a record in the database with an updated reset ttl and can be found before it reaches the updated ttl (5011ms)
      ✓ should update a record in the database with an updated reset ttl and expire after it reaches the updated ttl (3012ms)
      ✓ should run a find query with a limit of 1 and return 1 record
      ✓ should remove entities

  datastar-await-wrap
    ✓ should correctly wrap the create function
    ✓ should correctly wrap the update function
    ✓ should correctly wrap the remove function
    ✓ should correctly wrap the findOne function
    ✓ should correctly wrap the findAll function
    ✓ should return a stream from the findAllStream function
    ✓ should wrap ensureTables as the ensure function
    ✓ should wrap dropTables as the drop function

  Datastar (unit)
    ✓ should create datastar instance

  Model instance (unit)
    ✓ should "transform" data into an instance of the defined model
    json type handling
      ✓ should deserialize a json property
    Stringify an array, toJSON handling
      ✓ should contain the camelCase key when an array is stringified rather than snake_case
    #validate
      ✓ should validate the current data against the schema validation
      ✓ should return the validation error

  Model (unit)
    ✓ should create a model even with a missing name
    ✓ should create a model
    ✓ should create
    ✓ should error on create when no options are passed
    ✓ should be able to define a model with ensureTables option
    ✓ init() function should not call ensureTables if the ensureTables option is false
    ✓ init() function should call ensureTables if the ensureTables option is true
    - should be able to define a model with ensureTables option and error
    ✓ On find it should emit an error if passed bad fields and no callback
    ✓ should callback with an error if passed bad fields and a callback
    ✓ should error with an improper find type
    ✓ should find
    ✓ should find and return a stream if no callback is passed
    ✓ should run a count query
    ✓ should run a findFirst query
    ✓ should run a findOne query
    ✓ should remove a single entity

  Partial Statements
    with
      ✓ should return a with partial statement given appropriate options
      ✓ should return an error on the partial statement when it cannot process the given options

  Schema (unit)
    ✓ should create a schema
    ✓ should throw an error when given an invalid schema
    ✓ should throw an error when given an invalid name for the schema
    ✓ should transform the schema (snakecase and aliases)
    ✓ should validate the schema
    ✓ should allow for null values
    ✓ #fieldString() should return a list of all fields suitable for CQL consumption if no arguments are given
    ✓ #fieldString() should return a list of fields suitable for CQL consumption when a list of fields is given

  StatementBuilder
    FindStatement
      ✓ should return an find ALL statement if given an empty object or no options
      ✓ should return an find ALL statement with allow-filtering included
      ✓ should return an find statement with a field list if fields in options
      ✓ should return a find statement with a limit if specified in options
      ✓ should return an error when passed conditions that get filtered (non primary keys)
      ✓ should return a find statement with query params
    Lookup Tables
      ✓ (Find test) should return an error when passed conditions with conflicting lookup tables
      ✓ should return a valid statement that uses the proper lookup table for find when querying by domainName
      ✓ should return multiple statements to create for each lookup table
      ✓ should return a validation error when trying to create without all of the lookup tables
      ✓ should return multiple statements to delete from each lookup table
      ✓ should return an error when trying to delete with no conditions when there is a lookup table
      ✓ should return an error FOR NOW when trying to delete with insufficient conditions
      update
        ✓ should create a compound statement of compound statements with remove/create for looku tables
        ✓ should create a compound statement for lookup tables with 1 replacement for domain_name
    AlterStatement
      ✓ should return an error when given a bad type
      ✓ should return an error when given an unknown arg type
    TableStatment { schema } valid
      ✓ build()
      ✓ should return a proper TableStatement with orderBy option
      ✓ should return a proper TableStatement with orderBy option without order
      ✓ should return an error when given a bad key to orderBy
      ✓ should return a table statement with proper alterations
      ✓ should return a proper table statement with a schema that uses composite partition keys
      ✓ should return a proper table statement with a schema that uses a secondary or clustering key
      ✓ should return a proper TableStatement from _compile()
      ✓ should return a proper index TableStatement from _compile()
      ✓ should return a proper TableStatement from build()
      ✓ should return a proper index TableStatement from build()
      ✓ should return a proper TableStatement (lookup) from _compile()
      ✓ should return a proper index TableStatement (lookup) from _compile()
      ✓ should return a proper TableStatement (lookup) from build()
      ✓ should return a proper TableStatement for dropping the table from build()
      ✓ should return a proper TableStatement for dropping an index from build
      ✓ should return a proper index TableStatement (lookup) from build()
    RemoveStatement
      ✓ should return a proper RemoveStatement passed a single entity
      ✓ should return an error when passed an entity without a primary key
      ✓ should return an error when passed empty conditions 
      ✓ should return a proper RemoveStatement when passed a set of conditions
    UpdateStatement
      ✓ should return a proper update statement when given a artist object
      ✓ should return a proper statement with USING TTL if ttl options are passed
      ✓ should properly generate multiple statements when updating a set with add and remove
    CreateStatement
      ✓ should return a proper create statement when given a artist object
      ✓ should append USING TTL to the statement if it is passed as an option
      ✓ should return an error when given an improper entity


  138 passing (22s)
  1 pending
```